### PR TITLE
Added UseFileNameAsText parameter

### DIFF
--- a/CommonImageActions.AspNetCore/CommonImageActionSettings.cs
+++ b/CommonImageActions.AspNetCore/CommonImageActionSettings.cs
@@ -30,6 +30,8 @@ namespace CommonImageActions.AspNetCore
 
         public string RemoteFileServerUrl { get; set; }
 
+        public bool UseFileNameAsText { get; set; }
+
         public bool UseDiskCache { get; set; }
 
         public string DiskCacheLocation { get; set; }

--- a/CommonImageActions.AspNetCore/CommonImageActionsMiddleware.cs
+++ b/CommonImageActions.AspNetCore/CommonImageActionsMiddleware.cs
@@ -65,6 +65,16 @@ namespace CommonImageActions.AspNetCore
                 var imageActions = ConvertQueryStringToImageActions(uri.Query, _options.DefaultImageActions);
                 byte[] imageData = null;
 
+                //if the file name is to be used as text then set it
+                if (_options.UseFileNameAsText)
+                {
+                    var fileName = Path.GetFileNameWithoutExtension(imageFileRelativePath);
+                    if (string.IsNullOrEmpty(fileName) == false)
+                    {
+                        imageActions.Text = fileName;
+                    }
+                }
+
                 if (_options.UseDiskCache)
                 {
                     //make sure default disk cache location is set

--- a/CommonImageActions.SampleAspnetCoreProject/Program.cs
+++ b/CommonImageActions.SampleAspnetCoreProject/Program.cs
@@ -15,6 +15,24 @@ app.UseCommonImageActions(
 app.UseCommonImageActions(
     new CommonImageActionSettings()
     {
+        PathToWatch = "/user/icons/",
+        UseFileNameAsText = true,
+        IsVirtual = true,
+        DefaultImageActions = new ImageActions()
+        {
+            Height = 192,
+            Width = 192,
+            Format = SkiaSharp.SKEncodedImageFormat.Png,
+            Shape = ImageShape.Circle,
+            AsInitials = true,
+            ChooseImageColorFromTextValue = true
+        }
+    }
+);
+
+app.UseCommonImageActions(
+    new CommonImageActionSettings()
+    {
         PathToWatch = "/logos",
         DefaultImageActions = new ImageActions()
         {

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ app.UseCommonImageActions(
 | UseDiskCache | When true the system will save and return cached images. This can dramatically improve performance. |
 | DiskCacheLocation | Where to store and retrieve the DiskCache images from. This directory needs to be writable. If it is not the system will print errors to the console, but will still continue to run. |
 | DefaultImageActions | Set a default image action to be used on all requests against a particular path. Useful when you want all images in a directory to be a specific dimension. |
+| UseFileNameAsText | Use the filename to set the text value. For example `Dustin_Test.png` would be the same as `image.png?t=Dustin_Test` |
 
 ## Benchmarking
 Use [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) to compare the performance between 


### PR DESCRIPTION
Updated `CommonImageActionSettings` to include `UseFileNameAsText` and `UseDiskCache` properties. Enhanced `CommonImageActionsMiddleware` to utilize the filename as text when enabled. Modified `Program.cs` to configure these new settings and updated `README.md` to document the changes and provide usage examples.